### PR TITLE
Add GitHub Actions: Add labels to opened issue

### DIFF
--- a/.github/workflows/issues-opened-triage.yml
+++ b/.github/workflows/issues-opened-triage.yml
@@ -1,0 +1,19 @@
+name: Add labels to opened issue
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-label:
+    name: Add label to opened issue
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['waiting/triage', 'waiting/assign']
+            });


### PR DESCRIPTION
## What

- This pull request add GitHub Actions workflow to this repository that automatically add labels to newly opened GitHub Issues
- Clarify Issues where Triage and Assign have not been performed and encourage the `Benevolent Dictator` to do it

## Why

- I believe that every issues should be judged on the following by `Benevolent Dictator`
  - Determine priority of the issue ... Triage
  - Determine who is in responsible of the issue ... Assign

## How

- See the file `.github/workflows/issues-opened-triage.yml`
  - It runs when a new issue is opened
  - It gives two labels to the issue
    - `waiting/triage`
    - `waiting/assign`
- `Benevolent Dictator` will be...
  - Unlabeled `waiting/triage` once triage is performed
  - Unlabeled `waiting/assign` once assign is performed

## Message to @hfu 

- I have added the following labels to this repository
  - `waiting/triage`
  - `waiting/assign`
  - `priority/MAY`
  - `priority/SHOULD`
  - `priority/MUST`
  - `Request for Comments`

[![Image from Gyazo](https://i.gyazo.com/982c18fe4e86021271f318c31ab82618.png)](https://gyazo.com/982c18fe4e86021271f318c31ab82618)
