### PR TITLE
Fix `Create Weekly Issue`: Meetup Weekly date to show next week's date

### DIFF
--- a/.github/workflows/issues-weekly-creation.yml
+++ b/.github/workflows/issues-weekly-creation.yml
@@ -16,7 +16,7 @@ jobs:
           script: |
             const now = new Date();
             const nextTuesday = new Date(now);
-            nextTuesday.setDate(now.getDate() + ((2 + 7 - now.getDay()) % 7));
+            nextTuesday.setDate(now.getDate() + ((2 + 7 - now.getDay()) % 7) + 7);
             const year = nextTuesday.getFullYear();
             const month = String(nextTuesday.getMonth() + 1).padStart(2, '0');
             const day = String(nextTuesday.getDate()).padStart(2, '0');


### PR DESCRIPTION
Fixes #591

Modify the `Create Weekly Issue` workflow to generate issues with the date of the following week's meetup.

* Update the calculation of `nextTuesday` to add an additional 7 days.
* Update the `dateString` to reflect the new `nextTuesday` date.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/UNopenGIS/7/issues/591?shareId=7cf9e1d5-d5bb-42e8-8c1d-d9513b5e48ae).