### PR TITLE
Update README.md to new website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UN Smart Maps
 
-- [Documentation](https://unopengis.github.io/smartmaps)
+- [Web site](https://unopengis.org/DWG7.html)
 - [Issues](https://github.com/unopengis/7/issues)
 
 ## Social Preview Image


### PR DESCRIPTION
This pull request makes a minor update to the `README.md` file, replacing the "Documentation" link with a "Web site" link. This helps direct users to the main project website instead of the documentation page.

I have also submitted a pull request to update DWG-7.html on unopengis.org. Please review it.
- https://github.com/UNopenGIS/unopengis.github.io/pull/8